### PR TITLE
[ADD] new event for is_view update (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ To use environment variables for configuration, follow these steps:
    nats req NOTIFICATION.send-to-clients '{"type": "warning", "message": "example", "time": "2024-04-17T09:00:00Z", "clients": ["1", "2"], "is_view": false}'
    ```
 
+   Notification is viewed, so send event to update record
+   
+   ```shell
+   nats req NOTIFICATION.viewed '{"id": 1, "is_view": true}'
+   ```
+
 ## Example Client
 Here's a simple example of a client connecting to the WebSocket server and handling messages:
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -104,4 +104,19 @@ func microServices(nc *nats.Conn, wss *ws.Websocket, handler *handlers.MicroHand
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	_, err = micro.AddService(nc, micro.Config{
+		Name: handlers.StreamName,
+		Endpoint: &micro.EndpointConfig{
+			Subject:    handlers.SubjectNotificationViewed,
+			Handler:    handler.NotificationViewed(wss),
+			Metadata:   nil,
+			QueueGroup: "",
+		},
+		Version:     handlers.SubjectVersion,
+		Description: "",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Nicolas-ggd/go-notification
 go 1.22.2
 
 require (
-	github.com/Nicolas-ggd/gorm-metakit v0.5.7
+	github.com/Nicolas-ggd/gorm-metakit v0.5.8
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/nats-io/nats.go v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Nicolas-ggd/gorm-metakit v0.5.7 h1:dqmtw5LCFkMYrE9xwFT/PctWGnjs+79XLHkERg7m+SU=
-github.com/Nicolas-ggd/gorm-metakit v0.5.7/go.mod h1:4IgbU/+S4fLcJ0AENbUUgbwlBKL1+7qkzTztzTUMDqs=
+github.com/Nicolas-ggd/gorm-metakit v0.5.8 h1:rVfV4KuIBrwdGsr8iK2uCe6lAhYUa7E4ZKgg0zV+iSM=
+github.com/Nicolas-ggd/gorm-metakit v0.5.8/go.mod h1:LdKCxFj0XbItEO/UiReGh1wzRJG83HZ9xcL43Hgo5iQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-migrate/migrate/v4 v4.17.1 h1:4zQ6iqL6t6AiItphxJctQb3cFqWiSpMnX7wLTPnnYO4=

--- a/pkg/micro_handlers/config.go
+++ b/pkg/micro_handlers/config.go
@@ -6,5 +6,6 @@ const (
 	SubjectBroadcastNotification = "NOTIFICATION.send-to-all"
 	SubjectClientNotification    = "NOTIFICATION.send-to-clients"
 	SubjectNotificationList      = "NOTIFICATION.list"
+	SubjectNotificationViewed    = "NOTIFICATION.viewed"
 	SubjectVersion               = "0.0.1"
 )

--- a/pkg/micro_handlers/micro.go
+++ b/pkg/micro_handlers/micro.go
@@ -72,3 +72,19 @@ func (mh *MicroHandler) NotificationList(wss *ws.Websocket) micro.HandlerFunc {
 		fmt.Printf("%+v\n", meta)
 	}
 }
+
+func (mh *MicroHandler) NotificationViewed(wss *ws.Websocket) micro.HandlerFunc {
+	return func(r micro.Request) {
+		var m request.IsViewNotificationRequest
+
+		err := json.Unmarshal(r.Data(), &m)
+		if err != nil {
+			log.Println(err)
+		}
+
+		err = mh.NotificationService.Update(&m)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+}

--- a/pkg/repository/notification.go
+++ b/pkg/repository/notification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"github.com/Nicolas-ggd/go-notification/pkg/storage/models"
+	"github.com/Nicolas-ggd/go-notification/pkg/storage/models/request"
 	metakit "github.com/Nicolas-ggd/gorm-metakit"
 )
 
@@ -53,4 +54,24 @@ func (r *NotificationRepository) List(meta *metakit.Metadata) (*[]models.Notific
 	}
 
 	return &model, meta, nil
+}
+
+func (r *NotificationRepository) Update(model *request.ViewNotificationRequest) error {
+	query := `UPDATE notifications SET is_view=$1 WHERE id=$2;`
+
+	res, err := r.DB.Exec(query, model.IsView, model.ID)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
 }

--- a/pkg/services/notification.go
+++ b/pkg/services/notification.go
@@ -3,12 +3,14 @@ package services
 import (
 	"github.com/Nicolas-ggd/go-notification/pkg/repository"
 	"github.com/Nicolas-ggd/go-notification/pkg/storage/models"
+	"github.com/Nicolas-ggd/go-notification/pkg/storage/models/request"
 	metakit "github.com/Nicolas-ggd/gorm-metakit"
 )
 
 type INotificationService interface {
 	Insert(model *models.Notification) (*models.Notification, error)
 	List(meta *metakit.Metadata) (*[]models.Notification, *metakit.Metadata, error)
+	Update(model *request.IsViewNotificationRequest) error
 }
 
 type NotificationService struct {
@@ -37,4 +39,13 @@ func (ns *NotificationService) List(meta *metakit.Metadata) (*[]models.Notificat
 	}
 
 	return model, meta, nil
+}
+
+func (ns *NotificationService) Update(model *request.IsViewNotificationRequest) error {
+	err := ns.notificationRepository.Update(model.ToModel())
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/storage/models/request/notification.go
+++ b/pkg/storage/models/request/notification.go
@@ -13,6 +13,16 @@ type NotificationRequest struct {
 	Clients []string  `json:"clients"`
 }
 
+type IsViewNotificationRequest struct {
+	ID     uint `json:"id"`
+	IsView bool `json:"is_view"`
+}
+
+type ViewNotificationRequest struct {
+	ID     uint `json:"id"`
+	IsView int  `json:"is_view"`
+}
+
 func (nr *NotificationRequest) ToModel() *models.Notification {
 	return &models.Notification{
 		Type:    nr.Type,
@@ -20,4 +30,16 @@ func (nr *NotificationRequest) ToModel() *models.Notification {
 		Time:    nr.Time,
 		IsView:  nr.IsView,
 	}
+}
+
+func (nr *IsViewNotificationRequest) ToModel() *ViewNotificationRequest {
+	var v ViewNotificationRequest
+	v.ID = nr.ID
+	if nr.IsView {
+		v.IsView = 1
+	} else {
+		v.IsView = 0
+	}
+
+	return &v
 }


### PR DESCRIPTION
Add new NATS event service to listen `NOTIFICATION.viewed` to update record which is viewed, this is for future usage.

Now it's available to throw event: `nats req NOTIFICATION.viewed '{"id": 1, "is_view": true}'` and update record, but maybe `is_view` field is garbage in this table.