### PR TITLE
[ADD] priority queue to send notification according to priority type (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This microservice is designed to handle system notifications using Go, NATS, and
 - WebSocket Connectivity: It lets clients to access the service over WebSocket.
 - Broadcast Notifications: Messages are sent to all connected clients.
 - Targeted Notifications: Messages are sent to specific clients.
+- Priority Notifications: Notifications have different types and priorities (error, warning, info).
 - Easy Configuration: Command-line arguments can be used to configure the application.
 
 ## Installation
@@ -101,6 +102,14 @@ To use environment variables for configuration, follow these steps:
    ```shell
    nats req NOTIFICATION.viewed '{"id": 1, "is_view": true}'
    ```
+   
+## Notification Types and Priorities
+There are three types of system notifications, each with a different priority level:
+- Error: Highest priority. These notifications are sent first.
+- Warning: Medium priority. These notifications are sent after error notifications.
+- Info: Lowest priority. These notifications are sent last.
+
+If there is a list of notification that are received simultaneously, the client will receive this list in the following order as [described](#notification-types-and-priorities)
 
 ## Example Client
 Here's a simple example of a client connecting to the WebSocket server and handling messages:

--- a/pkg/queue/priority_queue.go
+++ b/pkg/queue/priority_queue.go
@@ -1,0 +1,61 @@
+package queue
+
+import (
+	"container/heap"
+	"github.com/Nicolas-ggd/go-notification/pkg/storage/models/request"
+	"sync"
+)
+
+type NotificationHeap request.NotificationRequest
+
+// An PriorityQueue is a min-heap of notifications.
+type PriorityQueue struct {
+	notification []*NotificationHeap
+	mutex        sync.Mutex
+}
+
+func (pq PriorityQueue) Len() int { return len(pq.notification) }
+
+func (pq PriorityQueue) Less(i, j int) bool {
+	priorities := map[string]int{
+		"error":   1,
+		"warning": 2,
+		"info":    3,
+	}
+
+	return priorities[pq.notification[i].Type] > priorities[pq.notification[j].Type]
+}
+
+func (pq PriorityQueue) Swap(i, j int) {
+	pq.notification[i], pq.notification[j] = pq.notification[j], pq.notification[i]
+}
+
+func (pq *PriorityQueue) Push(x interface{}) {
+	pq.mutex.Lock()
+	defer pq.mutex.Unlock()
+
+	item := x.(*NotificationHeap)
+	pq.notification = append(pq.notification, item)
+	heap.Fix(pq, pq.Len()-1)
+}
+
+func (pq *PriorityQueue) Pop() interface{} {
+	pq.mutex.Lock()
+	defer pq.mutex.Unlock()
+
+	old := pq.notification
+	n := len(old)
+	item := old[n-1]
+	pq.notification = old[0 : n-1]
+	heap.Init(pq)
+	return item
+}
+
+func NewPriorityQueue() *PriorityQueue {
+	pq := &PriorityQueue{
+		notification: []*NotificationHeap{},
+	}
+
+	heap.Init(pq)
+	return pq
+}

--- a/pkg/queue/priority_queue.go
+++ b/pkg/queue/priority_queue.go
@@ -14,9 +14,9 @@ type PriorityQueue struct {
 	mutex        sync.Mutex
 }
 
-func (pq PriorityQueue) Len() int { return len(pq.notification) }
+func (pq *PriorityQueue) Len() int { return len(pq.notification) }
 
-func (pq PriorityQueue) Less(i, j int) bool {
+func (pq *PriorityQueue) Less(i, j int) bool {
 	priorities := map[string]int{
 		"error":   1,
 		"warning": 2,
@@ -26,7 +26,7 @@ func (pq PriorityQueue) Less(i, j int) bool {
 	return priorities[pq.notification[i].Type] > priorities[pq.notification[j].Type]
 }
 
-func (pq PriorityQueue) Swap(i, j int) {
+func (pq *PriorityQueue) Swap(i, j int) {
 	pq.notification[i], pq.notification[j] = pq.notification[j], pq.notification[i]
 }
 

--- a/pkg/storage/models/request/notification.go
+++ b/pkg/storage/models/request/notification.go
@@ -6,6 +6,7 @@ import (
 )
 
 type NotificationRequest struct {
+	ID      uint      `json:"id"`
 	Type    string    `json:"type"`
 	Message string    `json:"message"`
 	Time    time.Time `json:"time"`


### PR DESCRIPTION
Implement priority queue to create notification queue list, use this list to send notification according to priority type. It's not finally interface of `queue` package, maybe in future we need to implement `priority` field of `int` type and `index` field for item in the heap.